### PR TITLE
Added check on dns.listen

### DIFF
--- a/start.js
+++ b/start.js
@@ -102,6 +102,7 @@ dns.on('error', function (err) {
 try {
   dns.listen(53, '0.0.0.0')
 } catch(err) {
+  console.log('Could not listen on port 53! Maybe another process is using it?')
   console.log(err.message)
   process.exit()
 }

--- a/start.js
+++ b/start.js
@@ -99,7 +99,12 @@ dns.on('error', function (err) {
   process.exit()
 })
 
-dns.listen(53, '0.0.0.0')
+try {
+  dns.listen(53, '0.0.0.0')
+} catch(err) {
+  console.log(err.message)
+  process.exit()
+}
 
 // Web server
 const app = express()


### PR DESCRIPTION
Prints a better message if port 53 fails, so everyone understands it.