### PR TITLE
Added start command for running seamlessly from docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ The development environment is configured by using Docker to remove software req
 
 1. Install the latest version of Docker [[OSX](https://docs.docker.com/docker-for-mac/install/)] [[Other](https://docs.docker.com/engine/installation/#supported-platforms)]
 2. Clone this repository.
-3. Run `./bin/docker-start.sh`
+3. Run `./bin/docker-start.sh`.
+
+## Windows Instructions
+
+1. Install the latest version of [Docker](https://docs.docker.com/engine/installation/#supported-platforms).
+2. Clone this repository.
+3. Run `bin\start-docker.bat`.
 
 Installation (Advanced)
 =======================

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Documentation
 
 API documentation for SploitCore is automatically generated using jsdoc comments.
 
-You can find the latest version of documentation hosted [here](https://reswitched.github.io/PegaSwitch/)
+You can find the latest version of documentation hosted [here](https://reswitched.github.io/pegaswitch/)
 
 To view locally: `npm run docs:serve` then visit `http://localhost:4001`
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,29 @@
   An exploit toolkit for the Nintendo Switch™
 </p>
 
-Installation
-============
+Installation (Simple)
+=====================
 
-1. Install the latest version of node from [nodejs.org](https://nodejs.org)
-2. Clone this repository
-3. Run `npm install`
+The development environment is configured by using Docker to remove software requirements from the host machine and to make updating easier.
+
+1. Install the latest version of Docker [[OSX](https://docs.docker.com/docker-for-mac/install/)] [[Other](https://docs.docker.com/engine/installation/#supported-platforms)]
+2. Clone this repository.
+3. Run `./bin/docker-start.sh`
+
+Installation (Advanced)
+=======================
+Alternatively, this can be ran without docker.
+
+1. Install the latest version of Node from [nodejs.org](https://nodejs.org/en/download/)
+2. Clone this repository.
+3. Run `npm install` to install node dependencies.
+4. Run `npm run start` to start thet service.
 
 Usage
 =====
 
-1. Ensure port 53, 80, and 8100 are open on the computer running pegaswitch.
-2. Start pegaswitch with `sudo node start.js`
+1. Ensure port 53, 80, and 8100 are open on the computer running PegaSwitch.
+2. Start PegaSwitch with `./bin/start-docker.sh`.
 3. Configure your Switch DNS settings to point to the IP of your computer.
 4. Run a connection test to trigger the Captive Portal. (Likewise, going into an update page will do the same.)
 5. **STRONG SUGGESTION**: If this is your first time running PegaSwitch on a new console, run the command `evalfile usefulscripts/SetupNew.js` to set up useful settings.
@@ -30,7 +41,7 @@ Documentation
 
 API documentation for SploitCore is automatically generated using jsdoc comments.
 
-You can find the latest version of documentation hosted [here](https://reswitched.github.io/pegaswitch/)
+You can find the latest version of documentation hosted [here](https://reswitched.github.io/PegaSwitch/)
 
 To view locally: `npm run docs:serve` then visit `http://localhost:4001`
 
@@ -41,18 +52,18 @@ Troubleshooting
 
 ### DNS responds with incorrect IP address
 
-You can override the IP address that pegaswitch responds with by passing an `--ip` argument to the `node start.js` command.
+You can override the IP address that PegaSwitch responds with by passing an `--ip` argument to the `node start.js` command.
 
 eg.
 ```
-sudo node start.js --ip 1.2.3.4
+./bin/start-docker.sh --ip 1.2.3.4
 ```
 
 ### Windows support
 
 The full curses interface on Windows is supported using WSL only. We will not provide support for native cmd.exe as it lacks necessary functionality.
 
-You can, however, use --disable-curses and write the debug log out to a file for ing.
+You can, however, use `--disable-curses` and write the debug log out to a file for viewing.
 
 License
 =======

--- a/bin/shell-docker.sh
+++ b/bin/shell-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker exec -ti pegaswitch /bin/bash

--- a/bin/start-docker.bat
+++ b/bin/start-docker.bat
@@ -11,7 +11,7 @@ set BIND_ADDRESS=0.0.0.0
 
 set DNS_PORT=53
 set WEB_PORT=80
-set OTHER_PORT=8100
+set WS_PORT=8100
 
 ECHO Starting PegaSwitch...
 
@@ -27,5 +27,5 @@ docker run --rm -it^
  -w "/opt/pegaswitch"^
  -p %BIND_ADDRESS%:%DNS_PORT%:53/udp^
  -p %BIND_ADDRESS%:%WEB_PORT%:80^
- -p %BIND_ADDRESS%:%OTHER_PORT%:8100^
+ -p %BIND_ADDRESS%:%WS_PORT%:8100^
  node:8 "/bin/bash" "-c" "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js %*;"

--- a/bin/start-docker.bat
+++ b/bin/start-docker.bat
@@ -28,4 +28,4 @@ docker run --rm -it^
  -p %BIND_ADDRESS%:%DNS_PORT%:53^
  -p %BIND_ADDRESS%:%WEB_PORT%:80^
  -p %BIND_ADDRESS%:%OTHER_PORT%:8100^
- node:8 "/bin/bash" "-c" "if [ -d node_modules ]; then npm install; fi; npm run start;"
+ node:8 "/bin/bash" "-c" "if [ -d \"node_modules\" ]; then npm install; fi; node start.js %*;"

--- a/bin/start-docker.bat
+++ b/bin/start-docker.bat
@@ -25,7 +25,7 @@ docker run --rm -it^
  --name "pegaswitch"^
  -v %ROOT_DIR%:"/opt/pegaswitch"^
  -w "/opt/pegaswitch"^
- -p %BIND_ADDRESS%:%DNS_PORT%:53^
+ -p %BIND_ADDRESS%:%DNS_PORT%:53/udp^
  -p %BIND_ADDRESS%:%WEB_PORT%:80^
  -p %BIND_ADDRESS%:%OTHER_PORT%:8100^
  node:8 "/bin/bash" "-c" "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js %*;"

--- a/bin/start-docker.bat
+++ b/bin/start-docker.bat
@@ -28,4 +28,4 @@ docker run --rm -it^
  -p %BIND_ADDRESS%:%DNS_PORT%:53^
  -p %BIND_ADDRESS%:%WEB_PORT%:80^
  -p %BIND_ADDRESS%:%OTHER_PORT%:8100^
- node:8 "/bin/bash" "-c" "if [ -d \"node_modules\" ]; then npm install; fi; node start.js %*;"
+ node:8 "/bin/bash" "-c" "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js %*;"

--- a/bin/start-docker.bat
+++ b/bin/start-docker.bat
@@ -1,0 +1,31 @@
+@echo off
+
+PUSHD %~dp0\..
+SET ROOT_DIR=%CD%
+POPD
+
+WHERE docker
+IF %ERRORLEVEL% NEQ 0 ECHO Docker must be installed to use this feature. Exiting...
+
+set BIND_ADDRESS=0.0.0.0
+
+set DNS_PORT=53
+set WEB_PORT=80
+set OTHER_PORT=8100
+
+ECHO Starting PegaSwitch...
+
+ECHO Windows may require permissions to access files. Be sure to watch for prompts/open windows by Docker.
+
+IF NOT EXIST %CD%\node_modules (
+    ECHO Node modules will be installed on first run
+)
+
+docker run --rm -it^
+ --name "pegaswitch"^
+ -v %ROOT_DIR%:"/opt/pegaswitch"^
+ -w "/opt/pegaswitch"^
+ -p %BIND_ADDRESS%:%DNS_PORT%:53^
+ -p %BIND_ADDRESS%:%WEB_PORT%:80^
+ -p %BIND_ADDRESS%:%OTHER_PORT%:8100^
+ node:8 "/bin/bash" "-c" "if [ -d node_modules ]; then npm install; fi; npm run start;"

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -33,4 +33,4 @@ docker run --rm -it \
   -p $BIND_ADDRESS:$DNS_PORT:53 \
   -p $BIND_ADDRESS:$WEB_PORT:80 \
   -p $BIND_ADDRESS:$OTHER_PORT:8100 \
-  node:8 /bin/bash -c 'if [ ! -d "node_modules" ]; then npm install; fi; node start.js $@'
+  node:8 /bin/bash -c "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js $@"

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -8,17 +8,19 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ "$(docker ps -aq -f name=pegaswitch)" ]; then
-    echo "Pegaswitch is already running..." >&2
+    echo "PegaSwitch is already running..." >&2
     exit 1
 fi
 
 ROOT_DIR="$(dirname $(pwd))"
 
+BIND_ADDRESS=0.0.0.0
+
 DNS_PORT=53
 WEB_PORT=80
 OTHER_PORT=8100
 
-echo "Starting Pegaswitch..."
+echo "Starting PegaSwitch..."
 
 if [ ! -d "node_modules" ]; then
     echo "Node modules will install on the first run"
@@ -28,7 +30,7 @@ docker run --rm -it \
   --name "pegaswitch" \
   -v $ROOT_DIR:/opt \
   -w /opt/pegaswitch \
-  -p 0.0.0.0:$DNS_PORT:53 \
-  -p 0.0.0.0:$WEB_PORT:80 \
-  -p 0.0.0.0:$OTHER_PORT:8100 \
+  -p $BIND_ADDRESS:$DNS_PORT:53 \
+  -p $BIND_ADDRESS:$WEB_PORT:80 \
+  -p $BIND_ADDRESS:$OTHER_PORT:8100 \
   node:8 /bin/bash -c 'if [ ! -d "node_modules" ]; then npm install; fi; node start.js $@'

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -9,6 +9,7 @@ fi
 
 if [ "$(docker ps -aq -f name=pegaswitch)" ]; then
     echo "PegaSwitch is already running..." >&2
+    echo "Use `docker stop pegaswitch` to stop the running instance and try again." >&2
     exit 1
 fi
 

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -27,6 +27,8 @@ if [ ! -d "node_modules" ]; then
     echo "Node modules will install on the first run"
 fi
 
+ARGS="$@"
+
 docker run --rm -it \
   --name "pegaswitch" \
   -v $ROOT_DIR:/opt \
@@ -34,4 +36,4 @@ docker run --rm -it \
   -p $BIND_ADDRESS:$DNS_PORT:53 \
   -p $BIND_ADDRESS:$WEB_PORT:80 \
   -p $BIND_ADDRESS:$OTHER_PORT:8100 \
-  node:8 /bin/bash -c "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js $@"
+  node:8 /bin/bash -c "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js $ARGS;"

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -31,4 +31,4 @@ docker run --rm -it \
   -p 0.0.0.0:$DNS_PORT:53 \
   -p 0.0.0.0:$WEB_PORT:80 \
   -p 0.0.0.0:$OTHER_PORT:8100 \
-  node:8 /bin/bash -c 'if [ ! -d "node_modules" ]; then npm install; fi; node start.js'
+  node:8 /bin/bash -c 'if [ ! -d "node_modules" ]; then npm install; fi; node start.js $@'

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -33,7 +33,7 @@ docker run --rm -it \
   --name "pegaswitch" \
   -v $ROOT_DIR:/opt \
   -w /opt/pegaswitch \
-  -p $BIND_ADDRESS:$DNS_PORT:53 \
+  -p $BIND_ADDRESS:$DNS_PORT:53/udp \
   -p $BIND_ADDRESS:$WEB_PORT:80 \
   -p $BIND_ADDRESS:$OTHER_PORT:8100 \
   node:8 /bin/bash -c "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js $ARGS;"

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -4,10 +4,11 @@ which docker
 
 if [ $? -ne 0 ]; then
     echo "Docker must be installed to use this feature. Exiting..." >&2
+    exit 1
 fi
 
 if [ "$(docker ps -aq -f name=pegaswitch)" ]; then
-    echo "Pegaswitch is already running..."
+    echo "Pegaswitch is already running..." >&2
     exit 1
 fi
 

--- a/bin/start-docker.sh
+++ b/bin/start-docker.sh
@@ -19,7 +19,7 @@ BIND_ADDRESS=0.0.0.0
 
 DNS_PORT=53
 WEB_PORT=80
-OTHER_PORT=8100
+WS_PORT=8100
 
 echo "Starting PegaSwitch..."
 
@@ -35,5 +35,5 @@ docker run --rm -it \
   -w /opt/pegaswitch \
   -p $BIND_ADDRESS:$DNS_PORT:53/udp \
   -p $BIND_ADDRESS:$WEB_PORT:80 \
-  -p $BIND_ADDRESS:$OTHER_PORT:8100 \
+  -p $BIND_ADDRESS:$WS_PORT:8100 \
   node:8 /bin/bash -c "if [ ! -d \"node_modules\" ]; then npm install; fi; node start.js $ARGS;"

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -14,10 +14,14 @@ OTHER_PORT=8100
 
 echo "Starting Pegaswitch..."
 
+if [ ! -d "node_modules" ]; then
+    echo "Node modules will install on the first run"
+fi
+
 docker run --rm -it \
   -v $ROOT_DIR:/opt \
   -w /opt/pegaswitch \
   -p 0.0.0.0:$DNS_PORT:53 \
   -p 0.0.0.0:$WEB_PORT:80 \
   -p 0.0.0.0:$OTHER_PORT:8100 \
-  node:8 node start.js
+  node:8 /bin/bash -c 'if [ ! -d "node_modules" ]; then npm install; fi; node start.js'

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -6,6 +6,11 @@ if [ $? -ne 0 ]; then
     echo "Docker must be installed to use this feature. Exiting..." >&2
 fi
 
+if [ "$(docker ps -aq -f name=pegaswitch)" ]; then
+    echo "Pegaswitch is already running..."
+    exit 1
+fi
+
 ROOT_DIR="$(dirname $(pwd))"
 
 DNS_PORT=53
@@ -19,6 +24,7 @@ if [ ! -d "node_modules" ]; then
 fi
 
 docker run --rm -it \
+  --name "pegaswitch" \
   -v $ROOT_DIR:/opt \
   -w /opt/pegaswitch \
   -p 0.0.0.0:$DNS_PORT:53 \

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+which docker
+
+if [ $? -ne 0 ]; then
+    echo "Docker must be installed to use this feature. Exiting..." >&2
+fi
+
+ROOT_DIR="$(dirname $(pwd))"
+
+DNS_PORT=53
+WEB_PORT=80
+OTHER_PORT=8100
+
+echo "Starting Pegaswitch..."
+
+docker run --rm -it \
+  -v $ROOT_DIR:/opt \
+  -w /opt/pegaswitch \
+  -p 0.0.0.0:$DNS_PORT:53 \
+  -p 0.0.0.0:$WEB_PORT:80 \
+  -p 0.0.0.0:$OTHER_PORT:8100 \
+  node:8 node start.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "start.js",
   "scripts": {
     "start": "node start.js",
+    "start-docker": "./bin/start-docker.sh",
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs:generate": "documentation build -f html -o docs ./exploit/**.js",
     "docs:serve": "documentation serve ./exploit/**.js"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node start.js",
     "start-docker": "./bin/start-docker.sh",
+    "shell": "./bin/shell-docker.sh",
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs:generate": "documentation build -f html -o docs ./exploit/**.js",
     "docs:serve": "documentation serve ./exploit/**.js"


### PR DESCRIPTION
This command will allow anyone with docker to easily build pegaswitch without needing the nodejs requirement on their local machine.

It will also have the added benefit of allowing pegaswitch to easily run on any platform without hassle.

Let me know if there's any feedback or improvements if this can get in!
