### PR TITLE
Quick Readme update and package.json fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ sudo node start.js --ip 1.2.3.4
 
 ### Windows support
 
-The full curses interface on Windows is supported using WSL only. We will not provide support for native cmd.exe as it lacks necessary functionality.
+To run pegaswitch on Windows (ensure the above ports are open):
 
-You can, however, use --disable-curses and write the debug log out to a file for ing.
+```
+C:\pegaswitch\> node start.js --disable-curses --logfile log.txt
+```
+
 
 License
 =======

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "express": "^4.15.2",
     "ip": "^1.1.5",
     "mkdirp": "^0.5.1",
-    "pty.js": "^0.3.1",
     "repl.history": "^0.1.4",
     "reserved-words": "^0.1.1",
     "source-map": "^0.5.6",


### PR DESCRIPTION
Remove pty reference (outdated, unmaintained package is referenced)
Make README a bit more clear for Windows users.