### PR TITLE
Windows user-friendliness updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ bundle.js
 memdumps
 dumps
 sourcemap
-package-lock.json
 build

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bundle.js
 memdumps
 dumps
 sourcemap
+package-lock.json
+build

--- a/README.md
+++ b/README.md
@@ -50,11 +50,18 @@ sudo node start.js --ip 1.2.3.4
 
 ### Windows support
 
-To run pegaswitch on Windows (ensure the above ports are open):
+Pegaswitch's core functionality should function on Windows 10, albeit without curses.
 
+Pegaswitch on Windows may not be actively maintained, as such, we suggest installing pegaswitch through WSL if you encounter problems. 
+
+If --logfile is not specified, pegaswitch.log is chosen by default. Open with text editor of your choice.
+
+ex:
 ```
-C:\pegaswitch\> node start.js --disable-curses --logfile log.txt
+C:\pegaswitch\> node start.js --logfile log.txt
 ```
+
+Curses on Windows is disabled.
 
 
 License

--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ sudo node start.js --ip 1.2.3.4
 
 ### Windows support
 
-The full curses interface on Windows is supported using WSL only. We will not provide support for native cmd.exe as it lacks necessary functionality.
+To run pegaswitch on Windows (ensure the above ports are open):
 
-You can, however, use --disable-curses and write the debug log out to a file for ing.
+```
+C:\pegaswitch\> node start.js --disable-curses --logfile log.txt
+```
+
 
 License
 =======

--- a/README.md
+++ b/README.md
@@ -50,19 +50,16 @@ sudo node start.js --ip 1.2.3.4
 
 ### Windows support
 
-Pegaswitch's core functionality should function on Windows 10, albeit without curses.
+Pegaswitch should function on Windows, albeit with the curses ui disabled.
 
-Pegaswitch on Windows may not be actively maintained, as such, we suggest installing pegaswitch through WSL if you encounter problems. 
-
-If --logfile is not specified, pegaswitch.log is chosen by default. Open with text editor of your choice.
+If --logfile is not specified, pegaswitch.log is used. You may open it with the text editor of your choice.
 
 ex:
 ```
 C:\pegaswitch\> node start.js --logfile log.txt
 ```
 
-Curses on Windows is disabled.
-
+If you encounter problems using pegaswitch on Windows, we suggest installing through WSL.
 
 License
 =======

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "express": "^4.15.2",
     "ip": "^1.1.5",
     "mkdirp": "^0.5.1",
-    "pty.js": "^0.3.1",
     "repl.history": "^0.1.4",
     "reserved-words": "^0.1.1",
     "source-map": "^0.5.6",

--- a/start.js
+++ b/start.js
@@ -36,18 +36,17 @@ let argv = yargs
 if(os.platform() === 'win32') {
 	if(!argv['disable-curses']) {
 		console.warn('WARNING: pegaswitch does not support curses on Windows. Curses disabled by default.');
-		//argv['disable-curses'] = true;
+		argv['disable-curses'] = true;
 	}
 
-} else if (os.platform() !== 'win32' && process.getuid() !== 0) {
+} else if (process.getuid() !== 0) {
 	console.error('Please run as root so we can bind to port 53 & 80');
 	process.exit();
 }	
 	
 if (argv['disable-curses'] && !argv.logfile) {
 	argv.logfile = 'pegaswitch.log'
-	console.warn('With curses disabled, --logfile is required, but was not found.');
-	console.log('Defaulting to \"pegaswitch.log\".');
+	console.warn('With curses disabled, a logfile (--logfile) is required. Defaulting to \"pegaswitch.log\".');
 }
 
 let logf = {
@@ -283,8 +282,7 @@ Promise.all([dnsServerStarted, httpServerStarted]).then(() => {
 	} else {
 		// Setup our terminal
 		let screen = blessed.screen({
-			smartCSR: true,
-			terminal: 'windows-ansi'
+			smartCSR: true
 		});
 
 		let log = contrib.log({


### PR DESCRIPTION
Round two of my windows-specific commits. 

1. If Windows is detected, we should automatically disable curses.
2. If no --logfile param is given and disable-curses is specified, we should use a default logfile. (I opted for pegaswitch.log, but the actual name of the log doesn't matter, imo)
3. Reword Windows Support section of the README.

Using Pegaswitch through WSL is a pain, however it is still doable, so I added a line at the bottom of the Windows support section.