### PR TITLE
Fix bug in trunclt64

### DIFF
--- a/exploit/utils.js
+++ b/exploit/utils.js
@@ -243,6 +243,9 @@ exports.trunclt32 = function (num, bits) {
 exports.trunclt64 = function (num, bits) {
 	num = this.pad64(num);
 	if(this.bits <= 32) {
+		if (num[1] !== 0) {
+			throw new Error("number is too large for " + bits + "bits");
+		}
 		return [this.trunclt32(num), 0];
 	}
 	// for some reason, a >> 32 == a. that makes literally no sense.


### PR DESCRIPTION
trunclt64 is supposed to throw if any truncated bits are non-zero.
However, if truncating to 32 or fewer bits, it failed to throw when
the upper 32 bits were non-zero.