### PR TITLE
Add nspwn.js to usefulscripts

### DIFF
--- a/usefulscripts/nspwn.js
+++ b/usefulscripts/nspwn.js
@@ -1,0 +1,12 @@
+/* PegaSwitch nspwn script to load HBmenu pre-3.0.0, nsp homebrew like reboot_to_rcm, etc */
+/* Originally posted by TuxSH on RS #switch-hacking-general */
+sc.getServices(["lr"], function (lr) {
+    var path = utils.str2ab("@Sdcard:/hbl.nsp"); /* put hbl.nsp on your SD card root */
+    var tid  = [0x100D, 0x01000000];        /* TID of the Album applet */
+    var storageId = 3;                      /* NAND (location of the Album applet) */
+
+    var msg = sc.ipcMsg(0).data(storageId).sendTo(lr).assertOk(); /* nn::lr::ILocationResolverManager(StorageId storageId) => nn::lr::ILocationResolver */
+    sc.withHandle(msg.movedHandles[0], (h) => {                   /* nn::lr::ILocationResolver::SetProgramNcaPath(u64 TID, const char *path) */
+        msg = sc.ipcMsg(1).data(tid).xDescriptor(path, path.byteLength, 0).sendTo(h).assertOk();
+    });
+});


### PR DESCRIPTION
[nx-hbmenu](https://github.com/switchbrew/nx-hbmenu) can be used on firmwares lower than 3.0.0, provided you have a way of triggering nspwn. This  script originally posted by TuxSH on RS' #switch-hacking-general provides a way to do so. This will look for "hbl.nsp" on the SD card; this NSP should be [nx-hbloader](https://github.com/switchbrew/nx-hbloader) if the goal is to boot nx-hbmenu, but it could also be something like [reboot_to_rcm](https://github.com/pixel-stuck/reboot_to_rcm), etc.

