### PR TITLE
Properly support domains in IPC

### DIFF
--- a/exploit/ipc.js
+++ b/exploit/ipc.js
@@ -24,6 +24,7 @@ function IPCMessage (sc, sender, cmdId) {
 	this.movedHandles = [];
 	this.objectDomainCommand = undefined;
 	this.objectId = 0;
+	this.inputObjectIds = [];
 	this.copyBuffers = [];
 }
 
@@ -145,6 +146,11 @@ IPCMessage.prototype.copyHandle = function (handle) {
 
 IPCMessage.prototype.moveHandle = function (handle) {
 	this.movedHandles.push(utils.trunc32(handle));
+	return this;
+};
+
+IPCMessage.prototype.inputObjectId = function (id) {
+	this.inputObjectId.push(utils.trunc32(id));
 	return this;
 };
 
@@ -329,7 +335,7 @@ IPCMessage.prototype.sendTo = function (handleName) {
 	}
 
 	if(ret.isOk) {
-		return new IPCMessage(this.sc, this.sender).unpack(this.sc.ipcBuf, false);
+		return new IPCMessage(this.sc, this.sender).unpack(this.sc.ipcBuf, this.objectDomainCommand != null);
 	} else {
 		return new IPCFailure(this.sc, this.sender, ret.getError());
 	}
@@ -362,7 +368,7 @@ IPCMessage.prototype.asyncSendTo = function (handleName, timeout) {
 		if (ret[0] !== 0) {
 			return new IPCFailure(self.sc, self.sender, new ResultCode(ret));
 		} else {
-			return new IPCMessage(self.sc, self.sender).unpack(ipcBuf, false);
+			return new IPCMessage(self.sc, self.sender).unpack(ipcBuf, this.objectDomainCommand != null);
 		}
 	});
 };
@@ -430,18 +436,17 @@ IPCMessage.prototype.unpack = function (buf, toDomain) {
 
 	var dataPayloadLength = alignedDataSectionLength;
 	if (toDomain) {
-		dataPayloadLength-= 0x10;
-    
+
 		this.objectDomainCommand = buf[pos] & 0xFF;
 
 		if(this.objectDomainCommand === 2) {
 			dataPayloadLength = 0;
 		}
-    
-		var dataLength = buf[pos++] >> 16;
-		if(dataLength != dataPayloadLength) {
-			throw new Error('data payload length in domain header != expected data payload length');
-		}
+
+		var dataLength = (buf[pos++] >> 16) + 0x10;
+		var inputObjectIdCount = (dataPayloadLength - dataLength - 0x10) / 4;
+		dataPayloadLength = dataLength;
+
 		this.objectId = buf[pos++];
 		pos+= 2;
 	}
@@ -463,6 +468,14 @@ IPCMessage.prototype.unpack = function (buf, toDomain) {
     
 		while (pos < dataPayloadBegin + (dataPayloadLength >> 2)) {
 			this.data.push(buf[pos++]);
+		}
+	}
+
+	if (toDomain) {
+		while (inputObjectIdCount > 0) {
+			// TODO: the u32 are technically unaligned.
+			this.inputObjectIds.push(buf[pos++]);
+			inputObjectIdCount -= 1;
 		}
 	}
 
@@ -494,6 +507,10 @@ IPCMessage.prototype.show = function () {
 	if (this.movedHandles.length > 0) {
 		utils.log('- Moved handles');
 		for (var i = 0; i < this.movedHandles.length; ++i) { utils.log('    - 0x' + this.movedHandles[i].toString(16)); }
+	}
+	if (this.inputObjectIds.length > 0) {
+		utils.log('- Input Objects');
+		for (var i = 0; i < this.inputObjectIds.length; ++i) { utils.log('    - 0x' + this.inputObjectIds[i].toString(16)); }
 	}
 	if (this.aDescriptors.length > 0) { utils.log('- ' + this.aDescriptors.length + ' A descriptor' + (this.aDescriptors.length > 1 ? 's' : '')); }
 	if (this.bDescriptors.length > 0) { utils.log('- ' + this.bDescriptors.length + ' B descriptor' + (this.bDescriptors.length > 1 ? 's' : '')); }
@@ -533,6 +550,9 @@ IPCMessage.prototype.toBuilderString = function () {
 	});
 	this.movedHandles.forEach((ch) => {
 		str+= ".moveHandle(0x" + ch.toString(16) + ")";
+	});
+	this.inputObjectIds.forEach((ch) => {
+		str+= ".inputObjectId(0x" + ch.toString(16) + ")";
 	});
 	if(this.objectDomainCommand) {
 		switch(this.objectDomainCommand) {
@@ -620,7 +640,7 @@ IPCFailure.prototype.withHandles = function(ok, err) {
 
 IPCFailure.prototype.show = function () {
 	utils.log("IPC Failure: " + this.resultCode.message + ", offending request shown below");
-	new IPCMessage(this.sc, this.sender).unpack(this.sc.ipcBuf, false).show();
+	new IPCMessage(this.sc, this.sender).unpack(this.sc.ipcBuf, this.objectDomainCommand != null).show();
 	return this;
 };
 


### PR DESCRIPTION
The implementation of domain messages in pegaswitch is currently broken. This fixes it.