### PR TITLE
Fix sploitMixin bug that doesn’t properly close service handles.

### DIFF
--- a/exploit/ipc.js
+++ b/exploit/ipc.js
@@ -709,7 +709,7 @@ sploitMixin.getServices = function(services, callback) {
 	try {
 		return callback.apply(undefined, serviceHandles);
 	} finally {
-		for (var shi = 0; si < serviceHandles.length; shi++) {
+		for (var shi = 0; shi < serviceHandles.length; shi++) {
 			this.svcCloseHandle(serviceHandles[shi]);
 		}
 	}


### PR DESCRIPTION
Currently, the for loop that closes service handles initializes a variable “shi” for the service handler index, and increments that variable. However, the actual check for finishing the loop is done using the older “si” variable that is set to the highest service handle.

This results in the service handles never being freed, as the condition is always false, unless the user added handles themself, in which case that for loop never exits, and the switch probably crashes eventually because an invalid handle gets freed.

<b>NOTE</b>: I do not have a Switch that is vulnerable to PegaSwitch or fusee-gelee, so I am unable to test this. Please test this code before merging it.